### PR TITLE
support Scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Scala client library for the [NATS messaging system](http://nats.io).
 ## Supported Platforms
 
 ```javascript
-- Scala 2.11.8+
+- Scala 2.11.8+ and 2.12+
 ```
 
 ## Getting Started

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,14 @@ name := "scala_nats"
 organization := "com.github.tyagihas"
 description := "scala_nats"
 
+def specs2(scalaVersion: String) =
+  (scalaVersion match {
+    case "2.11.8" => "org.scala-lang" % "scala-reflect" % "2.11.8"
+    case _        => "org.scala-lang" % "scala-reflect" % "2.12.2"
+  }) % "compile"
+
 publishMavenStyle := true
-libraryDependencies += "org.scala-lang" % "scala-reflect" % "2.12.2"
+libraryDependencies <++=  scalaVersion(sv => Seq(specs2(sv)))
 libraryDependencies += "com.github.tyagihas" % "java_nats" % "0.7.1"
 publishArtifact in Test := false
 
@@ -15,7 +21,7 @@ lazy val root = (project in file(".")).
     name := "scala_nats",
     version := "0.3.0",
     scalaVersion := "2.12.2"
-)
+)   
 
 resolvers += "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 resolvers += "Sonatype release Repository" at "http://oss.sonatype.org/service/local/staging/deploy/maven2/"

--- a/build.sbt
+++ b/build.sbt
@@ -5,14 +5,14 @@ name := "scala_nats"
 organization := "com.github.tyagihas"
 description := "scala_nats"
 
-def specs2(scalaVersion: String) =
+def scalaReflection(scalaVersion: String) =
   (scalaVersion match {
     case "2.11.8" => "org.scala-lang" % "scala-reflect" % "2.11.8"
     case _        => "org.scala-lang" % "scala-reflect" % "2.12.2"
   }) % "compile"
 
 publishMavenStyle := true
-libraryDependencies <++=  scalaVersion(sv => Seq(specs2(sv)))
+libraryDependencies <++=  scalaVersion(v => Seq(scalaReflection(v)))
 libraryDependencies += "com.github.tyagihas" % "java_nats" % "0.7.1"
 publishArtifact in Test := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.2"
 version := "0.3.0"
-crossScalaVersions := List("2.11.8")
+crossScalaVersions := List("2.11.8", "2.12.2")
 name := "scala_nats"
 organization := "com.github.tyagihas"
 description := "scala_nats"
 
 publishMavenStyle := true
-libraryDependencies += "org.scala-lang" % "scala-reflect" % "2.11.8"
+libraryDependencies += "org.scala-lang" % "scala-reflect" % "2.12.2"
 libraryDependencies += "com.github.tyagihas" % "java_nats" % "0.7.1"
 publishArtifact in Test := false
 
@@ -14,7 +14,7 @@ lazy val root = (project in file(".")).
   settings(
     name := "scala_nats",
     version := "0.3.0",
-    scalaVersion := "2.11.8"
+    scalaVersion := "2.12.2"
 )
 
 resolvers += "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"


### PR DESCRIPTION
Added support for Scala 2.12. Tested to use in a (maven) project, by first doing `sbt +publishM2` to install version 2.11 and 2.12.